### PR TITLE
Adding "is:" operator feature

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -50,6 +50,13 @@ var convert = function(query) {
             queryAll[group.field][mType] = _.flatten(queryAll[group.field][mType]);
         }
 
+        // simplify "!= true" to "= false"
+        else if (group.type === "!=" && group.value === true) {
+          group.type = "=";
+          group.value = false;
+          appendGroup(group, _.constant(group.value));
+        }
+
         // Other types
         else if (TYPES[group.type]) {
             appendGroup(group, function(value) {

--- a/lib/query.js
+++ b/lib/query.js
@@ -58,8 +58,8 @@ var splitGroup = function(group) {
     query: query,
     type: type || "=",
     value: value
-  }
-}
+  };
+};
 
 // Parse a group into an object representation
 var parseGroup = function(group, options) {
@@ -79,7 +79,7 @@ var parseGroup = function(group, options) {
           field: parts.query,
           type: '=',
           value: true
-        }
+        };
       }
     }
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -70,6 +70,18 @@ var parseGroup = function(group, options) {
     }
 
     var parts = splitGroup(group);
+    if (parts.field === 'is') {
+      var isField = options.fields[parts.query];
+      if (isField.query) {
+        parts = splitGroup(isField.query);
+      } else {
+        parts = {
+          field: parts.query,
+          type: '=',
+          value: true
+        }
+      }
+    }
 
     if (parts.length == 1) {
         parts.type = "in";

--- a/lib/query.js
+++ b/lib/query.js
@@ -45,6 +45,22 @@ var detectGroupType = function(group) {
     }) || "";
 };
 
+var splitGroup = function(group) {
+  var parts = group.split(FILTER_DELIMITER);
+  var field = removeQuotation(parts[0]);
+  var query = removeQuotation(parts.slice(1).join(FILTER_DELIMITER));
+  var type = detectGroupType(query);
+  var value = query.slice(type.length);
+
+  return {
+    length: parts.length,
+    field: field,
+    query: query,
+    type: type || "=",
+    value: value
+  }
+}
+
 // Parse a group into an object representation
 var parseGroup = function(group, options) {
     if (group == NOT_TYPE) {
@@ -53,24 +69,18 @@ var parseGroup = function(group, options) {
         };
     }
 
-
-    var parts = group.split(FILTER_DELIMITER);
-    var field = removeQuotation(parts[0]);
-    var query = removeQuotation(parts.slice(1).join(FILTER_DELIMITER));
-    var type = detectGroupType(query);
-    var value = query.slice(type.length);
-    type = type || "=";
+    var parts = splitGroup(group);
 
     if (parts.length == 1) {
-        type = "in";
-        value = tags.extract(field);
-        field = options.tags;
+        parts.type = "in";
+        parts.value = tags.extract(parts.field);
+        parts.field = options.tags;
     }
 
     return {
-        'type': type,
-        'field': field,
-        'value': value
+        'type': parts.type,
+        'field': parts.field,
+        'value': parts.value
     };
 };
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -65,19 +65,19 @@ var splitGroup = function(group) {
 var parseGroup = function(group, options) {
     if (group == NOT_TYPE) {
         return {
-            'type': NOT_TYPE
+            "type": NOT_TYPE
         };
     }
 
     var parts = splitGroup(group);
-    if (parts.field === 'is') {
+    if (parts.field === "is") {
       var isField = options.fields[parts.query];
       if (isField.query) {
         parts = splitGroup(isField.query);
       } else {
         parts = {
           field: parts.query,
-          type: '=',
+          type: "=",
           value: true
         };
       }
@@ -90,9 +90,9 @@ var parseGroup = function(group, options) {
     }
 
     return {
-        'type': parts.type,
-        'field': parts.field,
-        'value': parts.value
+        "type": parts.type,
+        "field": parts.field,
+        "value": parts.value
     };
 };
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -45,6 +45,27 @@ global.filter = new Filterable({
                     next(undefined, "_"+username);
                 }, 10);
             }
+        },
+        "published": {
+            type: Boolean
+        },
+        "admin": {
+            type: Boolean,
+            alias: "isAdmin"
+        },
+        "gender": {
+            type: String
+        },
+        "male": {
+            type: Boolean,
+            query: "gender:male"
+        },
+        "age": {
+            type: Number
+        },
+        "minor": {
+            type: Boolean,
+            query:"age:<18"
         }
     }
 });

--- a/test/queries.js
+++ b/test/queries.js
@@ -253,4 +253,64 @@ describe('Queries', function(done) {
       });
 
     });
+
+    describe('with "is:" operator', function() {
+
+      it('can handle "is:" for Booleans', function(done) {
+          testQuery('is:published',
+          {
+            "published": true
+          }, done);
+      });
+
+      it('can handle "NOT is:" for Booleans', function(done) {
+          testQuery('NOT is:published',
+          {
+            "published": false
+          }, done);
+      });
+
+      it('can handle "is:" for Booleans with "alias"', function(done) {
+          testQuery('is:admin',
+          {
+            "isAdmin": true
+          }, done);
+      });
+
+      it('can handle "NOT is:" for Booleans with "alias"', function(done) {
+          testQuery('NOT is:admin',
+          {
+            "isAdmin": false
+          }, done);
+      });
+
+      it('can handle "is:" with "query" (String)', function(done) {
+          testQuery('is:male',
+          {
+            "gender": "male"
+          }, done);
+      });
+
+      it('can handle "NOT is:" with "query" (String)', function(done) {
+          testQuery('NOT is:male',
+          {
+            "gender": { "$ne": "male" }
+          }, done);
+      });
+
+      it('can handle "is:" with "query" (Number)', function(done) {
+          testQuery('is:minor',
+          {
+            "age": { "$lt": 18 }
+          }, done);
+      });
+
+      it('can handle "NOT is:" with "query" (Number)', function(done) {
+          testQuery('NOT is:minor',
+          {
+            "age": { "$gte": 18 }
+          }, done);
+      });
+
+    });
 });


### PR DESCRIPTION
Implementing issue #8.

> This is a work in progress!

Opening early PR for discussion, as per @SamyPesse's suggestion.

Currently implemented:
- [x] refactor code to split groups into a reusable function
- [x] implement "is:" operator in `Filterable` class
- [x] unit tests

Still pending:
- [ ] implement "is:" operator in `FitlerablePlugin()`.
- [x] <del>update README</del> I'll submit this in a separate PR so it can be merged if and when this feature is landed.